### PR TITLE
Cleanup agent logging, increase default rdap retries

### DIFF
--- a/config/backend-config.yaml
+++ b/config/backend-config.yaml
@@ -80,4 +80,4 @@ prometheus:
 whois_manager:
   client_timeout: 2s
   cache_expiration_time: 12h
-  max_attempts: 3
+  max_attempts: 6

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -205,8 +205,6 @@ func (a *Agent) SendContext() error {
 			},
 		}
 
-		fmt.Printf("Sending context: %+v\n", &req)
-
 		if _, err = a.backendClient.SendSourceContext(&req); err != nil {
 			slog.Warn("error sending context RPC", slog.String("error", err.Error()))
 			// Continue and try to submit the others. Because in this case the cahce

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -14,13 +14,11 @@
 // You should have received a copy of the GNU General Public License along
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-//
 package agent
 
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"lophiid/backend_service"
 	"lophiid/pkg/backend"
@@ -89,7 +87,7 @@ func TestDownloadToBuffer(t *testing.T) {
 	}
 
 	if !bytes.Equal(testBody, resp.Data) {
-		fmt.Printf("expected %s, got %s", testBody, resp.Data)
+		t.Errorf("expected %s, got %s", testBody, resp.Data)
 	}
 }
 

--- a/pkg/agent/http_server.go
+++ b/pkg/agent/http_server.go
@@ -126,7 +126,7 @@ func (h *HttpServer) catchAll(w http.ResponseWriter, r *http.Request) {
 
 	raw, err := httputil.DumpRequest(r, true)
 	if err != nil {
-		fmt.Printf("Problem decoding requests: %s", err)
+		slog.Error("Problem decoding requests", slog.String("error", err.Error()), slog.String("request", fmt.Sprintf("%+#v", r)))
 	}
 
 	pr := &backend_service.HandleProbeRequest{
@@ -177,7 +177,7 @@ func (h *HttpServer) catchAll(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
-			log.Printf("parsing body: %s", err)
+			slog.Error("unable to parse body", slog.String("error", err.Error()))
 		} else {
 			pr.Request.Body = b
 		}
@@ -192,11 +192,10 @@ func (h *HttpServer) catchAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Printf("got request for: %s\n", pr.RequestUri)
+	slog.Debug("got new request", slog.String("request_uri", pr.RequestUri))
 
 	if res == nil || res.Response == nil {
-		fmt.Printf("Got nil ? Res: %+v, ProbeRequest: %+v\n", res, pr)
-		fmt.Printf("HTTP request: %+v\n", r)
+		slog.Error("got nil!!", slog.String("response", fmt.Sprintf("%+v", res)), slog.String("probe_request", fmt.Sprintf("%+v", pr)))
 		return
 	}
 

--- a/pkg/backend/config.go
+++ b/pkg/backend/config.go
@@ -97,6 +97,6 @@ type Config struct {
 	WhoisManager struct {
 		ClientTimeout       time.Duration `fig:"client_timeout" default:"2s"`
 		CacheExpirationTime time.Duration `fig:"cache_expiration_time" default:"12h"`
-		MaxAttempts         int           `fig:"max_attempts" default:"3"`
+		MaxAttempts         int           `fig:"max_attempts" default:"6"`
 	} `fig:"whois_manager"`
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implemented structured logging using `slog` throughout the agent and HTTP server, replacing `fmt.Printf` and `log.Printf` calls. This improves log consistency and provides better context for debugging.
- Increased the default number of RDAP lookup attempts from 3 to 6 in both the Go configuration struct and the YAML configuration file. This change aims to improve reliability when dealing with flaky RDAP services.
- Improved error reporting in test cases by replacing `fmt.Printf` with `t.Errorf` for better test output.
- Removed unnecessary debug logging in the `SendContext` function of the agent.
- Cleaned up imports by removing unused "fmt" import in the agent test file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.go</strong><dd><code>Remove debug logging in SendContext function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/agent.go

<li>Removed a debug print statement that was logging the context being <br>sent<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/43/files#diff-18bf746206c8ac217eb16ffb0cf91a6e676e05a7b517dc70aef0260d0871028f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent_test.go</strong><dd><code>Improve test error reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/agent_test.go

<li>Replaced a <code>fmt.Printf</code> statement with <code>t.Errorf</code> in a test case<br> <li> Removed an unused import of "fmt"<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/43/files#diff-367b401f7120e4ad05b0e984c25fc5e67096aa047f9761fcb6fd2bd8dbbb3922">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>http_server.go</strong><dd><code>Implement structured logging in HTTP server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/http_server.go

<li>Replaced <code>fmt.Printf</code> and <code>log.Printf</code> calls with structured logging using <br><code>slog</code><br> <li> Improved error logging with more context<br> <li> Changed debug print to use <code>slog.Debug</code><br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/43/files#diff-bd72f74c6c9e289f9aa548543a745b6a7a821fa744c26d2ba9325c7ae9179cff">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Increase default RDAP lookup attempts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/config.go

<li>Increased the default value of <code>MaxAttempts</code> in the <code>WhoisManager</code> <br>configuration from 3 to 6<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/43/files#diff-6952aeef04f3c18914ce220411813cd5ae63e7a9e5ffde064f5206e6dbaa71b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>backend-config.yaml</strong><dd><code>Update RDAP max attempts in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/backend-config.yaml

- Updated the `max_attempts` value under `whois_manager` from 3 to 6



</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/43/files#diff-422f5c2c60abdac2feda6fca8b0816bb571e902de5d73a2c5c9c430406dff9c5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

