### PR TITLE
Have honeypots report the ports they listen on

### DIFF
--- a/config/database.sql
+++ b/config/database.sql
@@ -127,6 +127,9 @@ CREATE TABLE honeypot (
   auth_token         VARCHAR(64) NOT NULL DEFAULT '',
   last_checkin       TIMESTAMP NOT NULL DEFAULT (timezone('utc', now())),
   default_content_id INT NOT NULL DEFAULT 0
+  ports              INT ARRAY,
+  ssl_ports          INT ARRAY,
+  cves            VARCHAR(15) ARRAY
 );
 
 CREATE TABLE app (

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -80,7 +80,7 @@ func (a *Agent) Start() error {
 		if s.ssl {
 			a.sslPorts = append(a.sslPorts, s.port)
 		} else {
-			a.ports = append(a.sslPorts, s.port)
+			a.ports = append(a.ports, s.port)
 		}
 
 		go func(server *HttpServer) {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -48,6 +48,8 @@ type Agent struct {
 	mimeInstance    *magicmime.Decoder
 	ipCache         *util.StringMapCache[bool]
 	p0fRunner       P0fRunner
+	ports           []int64
+	sslPorts        []int64
 }
 
 func NewAgent(backendClient backend.BackendClient, httpServers []*HttpServer, httpClient *http.Client, p0fRunner P0fRunner, statusInterval time.Duration, contextInterval time.Duration, reportIP string) *Agent {
@@ -75,6 +77,12 @@ func (a *Agent) Start() error {
 
 	slog.Info("Starting HTTP(S) servers")
 	for _, s := range a.httpServers {
+		if s.ssl {
+			a.sslPorts = append(a.sslPorts, s.port)
+		} else {
+			a.ports = append(a.sslPorts, s.port)
+		}
+
 		go func(server *HttpServer) {
 			// TODO: find a more elegant way
 			if a.p0fRunner != nil {
@@ -96,8 +104,10 @@ func (a *Agent) Start() error {
 				return
 			case <-ticker.C:
 				resp, err := a.backendClient.SendStatus(&backend_service.StatusRequest{
-					Ip:      a.reportIP,
-					Version: constants.LophiidVersion,
+					Ip:            a.reportIP,
+					Version:       constants.LophiidVersion,
+					ListenPort:    a.ports,
+					ListenPortSsl: a.sslPorts,
 				})
 
 				if err != nil {

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -347,10 +347,10 @@ func (s *BackendServer) SendStatus(ctx context.Context, req *backend_service.Sta
 		dms[0].Version = req.GetVersion()
 
 		dms[0].Ports = []int64{}
-		dms[0].Ports = append(dms[0].Ports, req.GetListenPort()...)
+		dms[0].Ports = req.GetListenPort()
 
 		dms[0].SSLPorts = []int64{}
-		dms[0].SSLPorts = append(dms[0].SSLPorts, req.GetListenPortSsl()...)
+		dms[0].SSLPorts = req.GetListenPortSsl()
 
 		if err := s.dbClient.Update(&dms[0]); err != nil {
 			return &backend_service.StatusResponse{}, status.Errorf(codes.Unavailable, "error updating honeypot: %s", err)

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -326,11 +326,17 @@ func (s *BackendServer) SendStatus(ctx context.Context, req *backend_service.Sta
 		return &backend_service.StatusResponse{}, status.Errorf(codes.NotFound, "error doing lookup")
 	}
 	if len(dms) == 0 {
-		_, err := s.dbClient.Insert(&database.Honeypot{
+
+		hp := &database.Honeypot{
 			IP:          req.GetIp(),
 			Version:     req.GetVersion(),
 			LastCheckin: time.Now(),
-		})
+		}
+
+		hp.Ports = append(hp.Ports, req.GetListenPort()...)
+		hp.SSLPorts = append(hp.Ports, req.GetListenPortSsl()...)
+
+		_, err := s.dbClient.Insert(hp)
 
 		if err != nil {
 			return &backend_service.StatusResponse{}, status.Errorf(codes.Unavailable, "error inserting honeypot: %s", err)
@@ -339,6 +345,13 @@ func (s *BackendServer) SendStatus(ctx context.Context, req *backend_service.Sta
 	} else {
 		dms[0].LastCheckin = time.Now()
 		dms[0].Version = req.GetVersion()
+
+		dms[0].Ports = []int64{}
+		dms[0].Ports = append(dms[0].Ports, req.GetListenPort()...)
+
+		dms[0].SSLPorts = []int64{}
+		dms[0].SSLPorts = append(dms[0].SSLPorts, req.GetListenPortSsl()...)
+
 		if err := s.dbClient.Update(&dms[0]); err != nil {
 			return &backend_service.StatusResponse{}, status.Errorf(codes.Unavailable, "error updating honeypot: %s", err)
 		}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -346,10 +346,7 @@ func (s *BackendServer) SendStatus(ctx context.Context, req *backend_service.Sta
 		dms[0].LastCheckin = time.Now()
 		dms[0].Version = req.GetVersion()
 
-		dms[0].Ports = []int64{}
 		dms[0].Ports = req.GetListenPort()
-
-		dms[0].SSLPorts = []int64{}
 		dms[0].SSLPorts = req.GetListenPortSsl()
 
 		if err := s.dbClient.Update(&dms[0]); err != nil {

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -727,8 +727,10 @@ func TestSendStatus(t *testing.T) {
 			getHoneypotError: nil,
 			dbErrorToReturn:  nil,
 			request: &backend_service.StatusRequest{
-				Ip:      "1.1.1.1",
-				Version: constants.LophiidVersion,
+				Ip:            "1.1.1.1",
+				Version:       constants.LophiidVersion,
+				ListenPort:    []int64{80},
+				ListenPortSsl: []int64{443},
 			},
 			expectedErrorString: "",
 		},
@@ -738,8 +740,10 @@ func TestSendStatus(t *testing.T) {
 			getHoneypotError: errors.New("boo"),
 			dbErrorToReturn:  nil,
 			request: &backend_service.StatusRequest{
-				Ip:      "1.1.1.1",
-				Version: constants.LophiidVersion,
+				Ip:            "1.1.1.1",
+				Version:       constants.LophiidVersion,
+				ListenPort:    []int64{80},
+				ListenPortSsl: []int64{443},
 			},
 			expectedErrorString: "error doing lookup",
 		},
@@ -749,8 +753,10 @@ func TestSendStatus(t *testing.T) {
 			getHoneypotError: nil,
 			dbErrorToReturn:  errors.New("foooo"),
 			request: &backend_service.StatusRequest{
-				Ip:      "1.1.1.1",
-				Version: constants.LophiidVersion,
+				Ip:            "1.1.1.1",
+				Version:       constants.LophiidVersion,
+				ListenPort:    []int64{80},
+				ListenPortSsl: []int64{443},
 			},
 			expectedErrorString: "error updating",
 		},
@@ -760,8 +766,10 @@ func TestSendStatus(t *testing.T) {
 			getHoneypotError: nil,
 			dbErrorToReturn:  errors.New("oh oh"),
 			request: &backend_service.StatusRequest{
-				Ip:      "1.1.1.1",
-				Version: constants.LophiidVersion,
+				Ip:            "1.1.1.1",
+				Version:       constants.LophiidVersion,
+				ListenPort:    []int64{80},
+				ListenPortSsl: []int64{443},
 			},
 			expectedErrorString: "error updating honeypot",
 		},
@@ -771,8 +779,10 @@ func TestSendStatus(t *testing.T) {
 			getHoneypotError: nil,
 			dbErrorToReturn:  nil,
 			request: &backend_service.StatusRequest{
-				Ip:      "1.1.1.1",
-				Version: constants.LophiidVersion,
+				Ip:            "1.1.1.1",
+				Version:       constants.LophiidVersion,
+				ListenPort:    []int64{80},
+				ListenPortSsl: []int64{443},
 			},
 			expectedErrorString: "",
 		},
@@ -813,6 +823,25 @@ func TestSendStatus(t *testing.T) {
 				t.Errorf("expected error \"%s\", to contain \"%s\"", err, test.expectedErrorString)
 			}
 
+			if test.dbErrorToReturn != nil {
+				lastDm := fdbc.LastDataModelSeen.(*database.Honeypot)
+
+				if len(lastDm.SSLPorts) != len(test.request.ListenPortSsl) {
+					t.Errorf("expected %d, got %d", len(test.request.ListenPortSsl), len(lastDm.SSLPorts))
+				}
+
+				if len(lastDm.Ports) != len(test.request.ListenPort) {
+					t.Errorf("expected %d, got %d", len(test.request.ListenPort), len(lastDm.Ports))
+				}
+
+				if lastDm.SSLPorts[0] != test.request.ListenPortSsl[0] {
+					t.Errorf("expected %d, got %d", test.request.ListenPortSsl[0], lastDm.SSLPorts[0])
+				}
+
+				if lastDm.Ports[0] != test.request.ListenPort[0] {
+					t.Errorf("expected %d, got %d", test.request.ListenPort[0], lastDm.Ports[0])
+				}
+			}
 		})
 	}
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -208,15 +208,17 @@ type RequestSourceContent struct {
 }
 
 type Honeypot struct {
-	ID                   int64     `ksql:"id,skipInserts" json:"id" doc:"The ID of the honeypot"`
-	IP                   string    `ksql:"ip" json:"ip" doc:"The IP of the honeypot (v4 or v6)"`
-	Version              string    `ksql:"version" json:"version" doc:"The honeypot version"`
-	AuthToken            string    `ksql:"auth_token" json:"auth_token" doc:"The authentication token"`
-	CreatedAt            time.Time `ksql:"created_at,skipInserts,skipUpdates" json:"created_at" doc:"Date and time of creation"`
-	UpdatedAt            time.Time `ksql:"updated_at,timeNowUTC" json:"updated_at" doc:"Date and time of last update"`
-	LastCheckin          time.Time `ksql:"last_checkin,skipInserts,skipUpdates" json:"last_checkin" doc:"Date and time of last seen"`
-	DefaultContentID     int64     `ksql:"default_content_id" json:"default_content_id" doc:"The Content ID that is served by default"`
-	RequestsCountLastDay int64     `json:"request_count_last_day"`
+	ID                   int64                   `ksql:"id,skipInserts" json:"id" doc:"The ID of the honeypot"`
+	IP                   string                  `ksql:"ip" json:"ip" doc:"The IP of the honeypot (v4 or v6)"`
+	Version              string                  `ksql:"version" json:"version" doc:"The honeypot version"`
+	AuthToken            string                  `ksql:"auth_token" json:"auth_token" doc:"The authentication token"`
+	CreatedAt            time.Time               `ksql:"created_at,skipInserts,skipUpdates" json:"created_at" doc:"Date and time of creation"`
+	UpdatedAt            time.Time               `ksql:"updated_at,timeNowUTC" json:"updated_at" doc:"Date and time of last update"`
+	LastCheckin          time.Time               `ksql:"last_checkin,skipInserts,skipUpdates" json:"last_checkin" doc:"Date and time of last seen"`
+	DefaultContentID     int64                   `ksql:"default_content_id" json:"default_content_id" doc:"The Content ID that is served by default"`
+	RequestsCountLastDay int64                   `json:"request_count_last_day"`
+	Ports                pgtype.FlatArray[int64] `ksql:"ports" json:"ports" doc:"HTTP ports that the honeypot listens on"`
+	SSLPorts             pgtype.FlatArray[int64] `ksql:"ssl_ports" json:"ssl_ports" doc:"HTTPS ports that the honeypot listens on"`
 }
 
 func (c *Honeypot) ModelID() int64 { return c.ID }

--- a/pkg/util/string_map_cache.go
+++ b/pkg/util/string_map_cache.go
@@ -23,13 +23,13 @@ import (
 	"time"
 )
 
-type CacheEntry[T comparable] struct {
+type CacheEntry[T any] struct {
 	Data          T
 	LastStoreTime time.Time
 	CreationTime  time.Time
 }
 
-type StringMapCache[T comparable] struct {
+type StringMapCache[T any] struct {
 	mu        sync.Mutex
 	entries   map[string]CacheEntry[T]
 	timeout   time.Duration
@@ -37,7 +37,7 @@ type StringMapCache[T comparable] struct {
 	cacheName string
 }
 
-func NewStringMapCache[T comparable](name string, timeout time.Duration) *StringMapCache[T] {
+func NewStringMapCache[T any](name string, timeout time.Duration) *StringMapCache[T] {
 	return &StringMapCache[T]{
 		timeout:   timeout,
 		cacheName: name,

--- a/ui/src/components/container/HoneypotForm.vue
+++ b/ui/src/components/container/HoneypotForm.vue
@@ -186,21 +186,8 @@ export default {
     honeypot() {
       this.localHoneypot = Object.assign({}, this.honeypot);
 
-      this.localHoneypot.ports.forEach((port) => {
-        if (this.localPorts == "") {
-          this.localPorts += port;
-        } else {
-          this.localPorts +=  ", " + port;
-        }
-      })
-
-      this.localHoneypot.ssl_ports.forEach((port) => {
-        if (this.localSSLPorts == "") {
-          this.localSSLPorts += port;
-        } else {
-          this.localSSLPorts +=  ", " + port;
-        }
-      })
+      this.localPorts = this.localHoneypot.ports.join(", ");
+      this.localSSLPorts = this.localHoneypot.ssl_ports.join(", ");
     },
   },
   created() {

--- a/ui/src/components/container/HoneypotForm.vue
+++ b/ui/src/components/container/HoneypotForm.vue
@@ -35,6 +35,21 @@
         />
       </div>
 
+
+      <div class="field">
+        <label class="label">HTTP Ports</label>
+
+        {{ localPorts }}
+      </div>
+
+      <div class="field">
+        <label class="label">HTTPS Ports</label>
+
+        {{ localSSLPorts }}
+      </div>
+
+
+
       <br/>
     <PrimeButton
       :label="localHoneypot.id > 0 ? 'Submit' : 'Add'"
@@ -89,6 +104,8 @@ export default {
   data() {
     return {
       localHoneypot: {},
+      localPorts: "",
+      localSSLPorts: "",
     };
   },
   methods: {
@@ -168,6 +185,22 @@ export default {
   watch: {
     honeypot() {
       this.localHoneypot = Object.assign({}, this.honeypot);
+
+      this.localHoneypot.ports.forEach((port) => {
+        if (this.localPorts == "") {
+          this.localPorts += port;
+        } else {
+          this.localPorts +=  ", " + port;
+        }
+      })
+
+      this.localHoneypot.ssl_ports.forEach((port) => {
+        if (this.localSSLPorts == "") {
+          this.localSSLPorts += port;
+        } else {
+          this.localSSLPorts +=  ", " + port;
+        }
+      })
     },
   },
   created() {


### PR DESCRIPTION
### **User description**
This PR finalizes the functionality where honeypots report the ports they listen on via the Status RPC. The ports are then stored in the database and displayed in the honeypot tab in the web UI


___

### **PR Type**
Enhancement


___

### **Description**
This PR implements the functionality for honeypots to report the ports they listen on and stores this information in the database. The main changes include:

- Agent: Added fields to store port information and included it in status reports.
- Backend: Updated to handle and store reported port information for honeypots.
- Database: Modified the Honeypot struct and database schema to include port fields.
- UI: Updated the HoneypotForm component to display HTTP and HTTPS ports.
- Tests: Updated backend tests to cover new port reporting functionality.
- Utility: Generalized the StringMapCache implementation for broader use.

These changes enable better tracking and display of honeypot configurations, improving system monitoring and management capabilities.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.go</strong><dd><code>Add port reporting to Agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/agent.go

<li>Added <code>ports</code> and <code>sslPorts</code> fields to the <code>Agent</code> struct<br> <li> Updated <code>Start</code> method to populate these fields<br> <li> Modified <code>SendStatus</code> call to include <code>ListenPort</code> and <code>ListenPortSsl</code><br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/68/files#diff-18bf746206c8ac217eb16ffb0cf91a6e676e05a7b517dc70aef0260d0871028f">+12/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>backend.go</strong><dd><code>Implement port storage in backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/backend.go

<li>Updated <code>SendStatus</code> function to handle and store reported ports<br> <li> Modified honeypot creation and update logic to include port <br>information<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/68/files#diff-c65bcfe9bb457434c3e69ba3f0576d7669935f350d24e2c2c58b05b4f9c510b2">+15/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>database.go</strong><dd><code>Add port fields to Honeypot struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/database/database.go

<li>Added <code>Ports</code> and <code>SSLPorts</code> fields to the <code>Honeypot</code> struct<br> <li> Updated field types to use <code>pgtype.FlatArray[int64]</code><br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/68/files#diff-1adb887d06a44193c36fc1c5708be385f3129cd59c2f2aa555faa065941ed877">+11/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>string_map_cache.go</strong><dd><code>Generalize StringMapCache implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/string_map_cache.go

<li>Modified <code>StringMapCache</code> and related functions to use generic type <code>T </code><br><code>any</code> instead of <code>T comparable</code><br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/68/files#diff-0ab41f6168af62cb8c68239c7c78cd0e807513c6264c91521b0f218500cbdb17">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HoneypotForm.vue</strong><dd><code>Add port display to Honeypot form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ui/src/components/container/HoneypotForm.vue

<li>Added display fields for HTTP and HTTPS ports<br> <li> Implemented logic to format and display port information<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/68/files#diff-e333339a49f1250cbbff50f56916c5c3c731bf7e1eb349da1553bee56dc119d7">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>database.sql</strong><dd><code>Update honeypot table schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/database.sql

<li>Added <code>ports</code> and <code>ssl_ports</code> columns to the <code>honeypot</code> table<br> <li> Added <code>cves</code> column to the <code>honeypot</code> table<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/68/files#diff-002629893f0a5eb6f8e9a6d036047c92784e918c0afc132f6992827aae6121bc">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_test.go</strong><dd><code>Update backend tests for port handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/backend_test.go

<li>Updated test cases to include <code>ListenPort</code> and <code>ListenPortSsl</code> in requests<br> <li> Added assertions to verify correct handling of port information<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/68/files#diff-841290eccbd676c43597489825cc8f1628359283c634321e496e76e31f6fed9c">+39/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information