### PR TITLE
Allow concurrent LLM lookups

### DIFF
--- a/cmd/backend/backend_main.go
+++ b/cmd/backend/backend_main.go
@@ -188,7 +188,7 @@ func main() {
 		pCache := util.NewStringMapCache[string]("LLM prompt cache", cfg.Responder.CacheExpirationTime)
 		llmMetrics := llm.CreateLLMMetrics(metricsRegistry)
 
-		llmManager := llm.NewLLMManager(llmClient, pCache, llmMetrics, cfg.Responder.LLMCompletionTimeout)
+		llmManager := llm.NewLLMManager(llmClient, pCache, llmMetrics, cfg.Responder.LLMCompletionTimeout, cfg.Responder.LLMConcurrentRequests)
 		llmResponder = responder.NewLLMResponder(llmManager, cfg.Responder.MaxInputCharacters)
 	} else {
 		llmResponder = nil

--- a/cmd/llm/main.go
+++ b/cmd/llm/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	pCache := util.NewStringMapCache[string]("LLM prompt cache", time.Hour)
 	llmMetrics := llm.CreateLLMMetrics(metricsRegistry)
-	llmManager := llm.NewLLMManager(llmClient, pCache, llmMetrics, time.Second*time.Duration(*timeoutSec))
+	llmManager := llm.NewLLMManager(llmClient, pCache, llmMetrics, time.Second*time.Duration(*timeoutSec), 5)
 	llmResponder := responder.NewLLMResponder(llmManager, *maxInputLength)
 	startTime := time.Now()
 

--- a/config/backend-config.yaml
+++ b/config/backend-config.yaml
@@ -99,5 +99,7 @@ responder:
   cache_expiration_time: 24h
   # How long a completion is allowed to take.
   llm_completion_timeout: 60s
+  # How many concurrent requests to send to the LLM API
+  llm_concurrent_requests: 5
   # Maximum string length of the prompt input.
   max_input_characters: 4096

--- a/deps.bzl
+++ b/deps.bzl
@@ -1017,6 +1017,13 @@ def go_dependencies():
         version = "v0.1.4",
     )
     go_repository(
+        name = "com_github_sourcegraph_conc",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/sourcegraph/conc",
+        sum = "h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=",
+        version = "v0.3.0",
+    )
+    go_repository(
         name = "com_github_spaolacci_murmur3",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/spaolacci/murmur3",
@@ -1398,8 +1405,8 @@ def go_dependencies():
         name = "org_uber_go_multierr",
         build_file_proto_mode = "disable_global",
         importpath = "go.uber.org/multierr",
-        sum = "h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=",
-        version = "v1.6.0",
+        sum = "h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=",
+        version = "v1.9.0",
     )
     go_repository(
         name = "org_uber_go_zap",

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/prometheus/procfs v0.13.0 // indirect
 	github.com/rakyll/magicmime v0.1.0 // indirect
 	github.com/sashabaranov/go-openai v1.30.0 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
+github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/pkg/backend/config.go
+++ b/pkg/backend/config.go
@@ -101,11 +101,12 @@ type Config struct {
 	} `fig:"whois_manager"`
 
 	Responder struct {
-		Enable               bool          `fig:"enable" default:"0"`
-		ApiLocation          string        `fig:"api_location" default:"http://localhost:8000/v1"`
-		ApiKey               string        `fig:"api_key"`
-		CacheExpirationTime  time.Duration `fig:"cache_expiration_time" default:"24h"`
-		LLMCompletionTimeout time.Duration `fig:"llm_completion_timeout" default:"1m"`
-		MaxInputCharacters   int           `fig:"max_input_characters" default:"4096"`
+		Enable                bool          `fig:"enable" default:"0"`
+		ApiLocation           string        `fig:"api_location" default:"http://localhost:8000/v1"`
+		ApiKey                string        `fig:"api_key"`
+		CacheExpirationTime   time.Duration `fig:"cache_expiration_time" default:"24h"`
+		LLMCompletionTimeout  time.Duration `fig:"llm_completion_timeout" default:"1m"`
+		LLMConcurrentRequests int           `fig:"llm_concurrent_requests" default:"5"`
+		MaxInputCharacters    int           `fig:"max_input_characters" default:"4096"`
 	} `fig:"responder"`
 }

--- a/pkg/backend/responder/BUILD.bazel
+++ b/pkg/backend/responder/BUILD.bazel
@@ -20,5 +20,10 @@ go_test(
     name = "responder_test",
     srcs = ["llm_responder_test.go"],
     embed = [":responder"],
-    deps = ["//pkg/util"],
+    deps = [
+        "//pkg/llm",
+        "//pkg/util",
+        "//pkg/util/constants",
+        "@com_github_prometheus_client_golang//prometheus",
+    ],
 )

--- a/pkg/backend/responder/llm_prompts.go
+++ b/pkg/backend/responder/llm_prompts.go
@@ -17,13 +17,10 @@
 package responder
 
 var commandInjectionPrompt = `
-You are a computer terminal and receive one command to execute. If you know the command then provide an example output. If the command is not known just provide an empty reply. Do not provide any analysis or description of the command. Just provide the output.
+You are a computer terminal and receive a command-line command to execute. If you know the command-line command, which is written below, then provide an example output. If the command is not known just provide an empty reply. Do not provide any analysis, breakdown or description.
 
-If a command contains the substring "$?" than replace that part of the command with the character 0.
-If you echo a string, always add a newline at the end of the string unless echo is used with the -n flag.
-
-The command is:
 %s
+
 `
 var sourceCodeExecutionPrompt = `
 You are a computer that is given source code. Tell me what output this source code produces. Just give the output and do not provide any analysis. If there is no output than simply give an empty reply.

--- a/pkg/llm/BUILD.bazel
+++ b/pkg/llm/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sashabaranov_go_openai//:go-openai",
+        "@com_github_sourcegraph_conc//pool",
     ],
 )
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented concurrent LLM lookups to improve performance and efficiency
- Added a new configuration option `llm_concurrent_requests` to control the number of concurrent requests
- Updated LLMManager to support parallel processing of multiple prompts
- Refactored command injection responder to use concurrent LLM lookups
- Added new tests for concurrent LLM completions and command injection responder
- Updated dependencies to include a concurrent processing library
- Modified configuration files and build scripts to support the new changes



___



PRDescriptionHeader.CHANGES_WALKTHROUGH
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_main.go</strong><dd><code>Add concurrent requests parameter to LLMManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/backend/backend_main.go

<li>Updated <code>NewLLMManager</code> call to include a new parameter <br><code>cfg.Responder.LLMConcurrentRequests</code><br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-aea9d0ad7326cd6083f662c484917c42ab9ff66183cbe981873c671cedc76b7c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add concurrent requests to LLMManager in main</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/llm/main.go

<li>Modified <code>NewLLMManager</code> call to include a new parameter for concurrent <br>requests (set to 5)<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-733501c64048a9c28435343cfa138c8892120de440b9febe8d0d24d320a5690b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>llm_prompts.go</strong><dd><code>Refine command injection prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/responder/llm_prompts.go

<li>Updated the command injection prompt to be more specific about <br>command-line commands<br> <li> Removed instructions about <code>$?</code> substring and echo behavior<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-f291f4d856d323fd38dc6804fdecac72fc944301c31575ac7a59ebe8054ec533">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>llm_responder.go</strong><dd><code>Implement concurrent LLM lookups for command injection</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/responder/llm_responder.go

<li>Implemented concurrent LLM lookups for command injection responses<br> <li> Added error handling for cases with no commands<br> <li> Used <code>CompleteMultiple</code> method from LLMManager for parallel processing<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-c3e93e5adb1e4d4cdb55ce0b82481329eb36fe0db2b23559380252ff22c5969d">+22/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>llm_manager.go</strong><dd><code>Implement concurrent LLM completions in LLMManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/llm/llm_manager.go

<li>Added <code>multiplePoolSize</code> field to LLMManager struct<br> <li> Implemented <code>CompleteMultiple</code> method for parallel prompt completions<br> <li> Updated <code>NewLLMManager</code> to include pool size parameter<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-079422eef64450f8a3d97a65b202d2a89a3850d6dd9282c9a8f930bd3731c26a">+30/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add LLMConcurrentRequests to Responder config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/config.go

<li>Added new field <code>LLMConcurrentRequests</code> to the Responder struct<br> <li> Set default value for <code>LLMConcurrentRequests</code> to 5<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-6952aeef04f3c18914ce220411813cd5ae63e7a9e5ffde064f5206e6dbaa71b1">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>backend-config.yaml</strong><dd><code>Add concurrent requests config option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/backend-config.yaml

<li>Added new configuration option <code>llm_concurrent_requests</code> with default <br>value 5<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-422f5c2c60abdac2feda6fca8b0816bb571e902de5d73a2c5c9c430406dff9c5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Update Bazel build for responder tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/responder/BUILD.bazel

- Added new dependencies for responder tests



</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-7f720dcb3edd95c70be2b43e3b4cc77a4b26ffe53aabe641166d13b216a031df">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Update Bazel build for LLM package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/llm/BUILD.bazel

- Added new dependency `@com_github_sourcegraph_conc//pool`



</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-756699b74c76793b70cc9c9b4c8735377aefafc2a1a433b4fed40c4f0caa2dc1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>llm_responder_test.go</strong><dd><code>Add tests for command injection responder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/responder/llm_responder_test.go

<li>Added new test cases for command injection responder<br> <li> Implemented tests for single and multiple command completions<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-5cd544475e17a44a614f538c100dcbbc340a1dca7fed1b03d237fbe06875eb1b">+55/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>llm_manager_test.go</strong><dd><code>Add tests for concurrent LLM completions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/llm/llm_manager_test.go

<li>Updated existing tests to include new pool size parameter<br> <li> Added new test case for <code>CompleteMultiple</code> method<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-e03782aea4d40f7c5571a29769371132bccee06d8d77503a54ae4374e6543489">+29/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>deps.bzl</strong><dd><code>Add concurrent library dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deps.bzl

<li>Added new dependency <code>com_github_sourcegraph_conc</code><br> <li> Updated version of <code>org_uber_go_multierr</code><br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-fab376ba1470f856c3cef704121107abeb9ad4766665f4cc6315bb5a6d14bac1">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Add concurrent library to go.mod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

- Added new dependency `github.com/sourcegraph/conc v0.3.0`



</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update go.sum with new dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.sum

<li>Added checksum for new dependency <code>github.com/sourcegraph/conc v0.3.0</code><br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/70/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information