### PR TITLE
Fix concurrency issue

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -278,7 +278,7 @@ func (s *BackendServer) GetMatchedRule(rules []database.ContentRule, req *databa
 	// Find out what rules match but haven't been served.
 	for _, r := range matchedRules {
 
-		if _, ok := session.RuleIDsServed[r.ID]; !ok {
+		if !session.HasServedRule(r.ID) {
 			unservedRules = append(unservedRules, r)
 
 			// A rule matching the same app id is prefered.
@@ -305,7 +305,7 @@ func (s *BackendServer) GetMatchedRule(rules []database.ContentRule, req *databa
 
 func (s *BackendServer) UpdateSessionWithRule(ip string, session *database.Session, rule *database.ContentRule) {
 	session.LastRuleServed = *rule
-	session.RuleIDsServed[rule.ID] = rule.ContentID
+	session.ServedRuleWithContent(rule.ID, rule.ContentID)
 	if err := s.sessionMgr.UpdateCachedSession(ip, session); err != nil {
 		slog.Error("error updating session", slog.String("ip", ip), slog.String("error", err.Error()))
 	}

--- a/pkg/backend/session/session.go
+++ b/pkg/backend/session/session.go
@@ -121,12 +121,10 @@ func (d *DatabaseSessionManager) SaveExpiredSession(session *database.Session) b
 // StartNewSession starts a new session for the given IP and stores the session
 // in the cache.
 func (d *DatabaseSessionManager) StartSession(ip string) (*database.Session, error) {
-	newSession := &database.Session{
-		Active:    true,
-		StartedAt: time.Now().UTC(),
-		IP:        ip,
-		RuleIDsServed: make(map[int64]int64),
-	}
+	newSession := database.NewSession()
+	newSession.Active = true
+	newSession.StartedAt = time.Now().UTC()
+	newSession.IP = ip
 
 	dm, err := d.dbClient.Insert(newSession)
 	if err != nil {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -408,6 +408,13 @@ func (c *Session) ServedRuleWithContent(ruleID int64, contentID int64) {
 	c.RuleIDsServed[ruleID] = contentID
 }
 
+// NewSession creates a new session.
+func NewSession() *Session {
+	return &Session{
+		RuleIDsServed: make(map[int64]int64),
+	}
+}
+
 type DatabaseClient interface {
 	Close()
 	Insert(dm DataModel) (DataModel, error)


### PR DESCRIPTION
### **User description**
Fix an issue where the session map was access concurrently


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Addressed a concurrency issue in the Session struct by adding a mutex and thread-safe methods
- Implemented `HasServedRule()` method to check if a rule has been served, using a read lock
- Added `ServedRuleWithContent()` method to update served rules, using a write lock
- Updated `GetMatchedRule()` and `UpdateSessionWithRule()` to use the new thread-safe methods
- Improved code safety and reliability by preventing race conditions when accessing shared session data



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Concurrency</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend.go</strong><dd><code>Implement thread-safe session access methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/backend.go

<li>Replaced direct access to <code>session.RuleIDsServed</code> with <br><code>session.HasServedRule()</code> method<br> <li> Updated <code>UpdateSessionWithRule</code> to use <code>session.ServedRuleWithContent()</code> <br>method<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/81/files#diff-c65bcfe9bb457434c3e69ba3f0576d7669935f350d24e2c2c58b05b4f9c510b2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>database.go</strong><dd><code>Add thread-safe methods to Session struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/database/database.go

<li>Added <code>sync.RWMutex</code> to <code>Session</code> struct for thread-safe operations<br> <li> Implemented <code>HasServedRule()</code> method with read lock<br> <li> Implemented <code>ServedRuleWithContent()</code> method with write lock<br>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/81/files#diff-1adb887d06a44193c36fc1c5708be385f3129cd59c2f2aa555faa065941ed877">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information