### PR TITLE
Add single rule for 14 TP-Link routers (WR741ND, R402M, MR3420 ...)

### DIFF
--- a/rules/TP-Link/TP-Link-Collection-multiple.yaml
+++ b/rules/TP-Link/TP-Link-Collection-multiple.yaml
@@ -1,0 +1,62 @@
+app:
+    id: 161
+    name: Collection
+    version: multiple
+    vendor: TP-Link
+    os: ""
+    link: ""
+    created_at: 2025-01-14T09:09:24.715907Z
+    updated_at: 2025-01-14T14:21:23.88781Z
+    ext_version: 0
+    ext_uuid: bf4697d0-7160-4d0e-82e9-d72fdd17f3e4
+    cves: []
+rules:
+    - id: 695
+      uri: /
+      body: ""
+      method: GET
+      port: 0
+      uri_matching: exact
+      body_matching: none
+      content_id: 691
+      app_id: 161
+      app_uuid: bf4697d0-7160-4d0e-82e9-d72fdd17f3e4
+      content_uuid: c2298f9f-b466-4734-8973-9404bb8b38e2
+      created_at: 2025-01-14T14:10:32.193389Z
+      updated_at: 2025-01-14T14:10:32.193268Z
+      alert: false
+      enabled: true
+      ext_version: 0
+      ext_uuid: 593e296b-e51a-4832-afc6-f860941238ab
+      request_purpose: UNKNOWN
+      responder: NONE
+      responder_regex: ""
+      responder_decoder: NONE
+contents:
+    - id: 691
+      data: PCFET0NUWVBFIEhUTUwgUFVCTElDICItLy9XM0MvL0RURCBIVE1MIDQuMDEgVHJhbnNpdGlvbmFsLy9FTiIgDQogICJodHRwOi8vd3d3LnczLm9yZy9UUi9odG1sNC9sb29zZS5kdGQiPg0KPEhUTUw+DQo8SEVBRD4NCjxUSVRMRT5Mb2dpbiBJbmNvcnJlY3Q8L1RJVExFPg0KPE1FVEEgaHR0cC1lcXVpdj0iQ29udGVudC1UeXBlIiBjb250ZW50PSJ0ZXh0L2h0bWw7IGNoYXJzZXQ9aXNvLTg4NTktMSI+DQo8U1RZTEUgdHlwZT0idGV4dC9jc3MiPg0KYm9keSwgcCB7DQoJZm9udC1mYW1pbHk6QXJpYWw7DQoJZm9udC1zaXplOjE0cHg7DQoJbGluZS1oZWlnaHQ6MTgwJTsNCgl0ZXh0LWFsaWduOmxlZnQ7DQp9DQpoMSB7DQoJdGV4dC1hbGlnbjpsZWZ0Ow0KCWZvbnQtc2l6ZTozMHB4Ow0KCWxpbmUtaGVpZ2h0Om5vcm1hbDsNCgljb2xvcjojMDA2OEIxDQp9DQojZXJyb3Jib2R5IHsNCgl3aWR0aDo2MjBweDsNCglkaXNwbGF5OmJsb2NrOw0KCXBhZGRpbmctdG9wOjVlbQ0KfQ0KPC9TVFlMRT4NCjwvSEVBRD4NCjxCT0RZPg0KPERJViBhbGlnbj0iY2VudGVyIj4NCiAgPERJViBpZD0iZXJyb3Jib2R5Ij4NCiAgICA8SDE+VXNlcm5hbWUgb3IgUGFzc3dvcmQgaXMgaW5jb3JyZWN0LjxCUj4NCiAgICAgIFBsZWFzZSByZWZlciB0byB0aGUgdHJvdWJsZXNob290aW5nIGJlbG93OjwvSDE+DQogICAgPEJSPg0KICAgIDxQPiA8Qj48Rk9OVCBzaXplPSI0Ij5JcyB0aGUgJnF1b3Q7Q2FwcyBMb2NrJnF1b3Q7IGVuYWJsZWQgb24geW91ciBrZXlib2FyZD88L0ZPTlQ+PC9CPiA8QlI+DQogICAgICBUaGUgdXNlcm5hbWUgYW5kIHBhc3N3b3JkIG11c3QgYmUgbG93ZXJjYXNlLCBwbGVhc2UgZW5zdXJlIHRoYXQgdGhlICZxdW90O0NhcHMgTG9jayZxdW90OyBMRUQgaXMgZGlzYWJsZWQgb24geW91ciBrZXlib2FyZCBhbmQgdHJ5IGFnYWluLjwvUD4NCiAgICA8UD48Qj48Rk9OVCBzaXplPSI0Ij5Gb3Jnb3QgeW91ciB1c2VybmFtZSBvciBwYXNzd29yZD88L0ZPTlQ+PC9CPjxCUj4NCiAgICAgIFBsZWFzZSByZXNldCB0aGUgZGV2aWNlIHRvIHRoZSBmYWN0b3J5IGRlZmF1bHQgc2V0dGluZ3MgaWYgeW91IGhhdmUgZm9yZ290dGVuIHlvdXIgdXNlcm5hbWUgb3IgcGFzc3dvcmQuIFRoZSBkZWZhdWx0IHVzZXJuYW1lIGFuZCBwYXNzd29yZCBhcmUgYm90aCBzZXQgYXMgPEI+JnF1b3Q7YWRtaW4mcXVvdDs8L0I+LjxCUj4NCiAgICAgIDxCPjxGT05UIGNvbG9yPSNlZTAwMDA+Tm90ZTogVGhlIHNldHRpbmdzIHdpbGwgYmUgcmVzdG9yZWQgdG8gZmFjdG9yeSBkZWZhdWx0IGFmdGVyIHRoZSByZXNldHRpbmcuPC9GT05UPjwvQj48L1A+DQogICAgPFA+PEI+PEZPTlQgc2l6ZT0iNCI+SG93IHRvIHJlc3RvcmUgdGhlIGRldmljZSB0byB0aGUgZmFjdG9yeSBkZWZhdWx0IHNldHRpbmdzPzwvRk9OVD48L0I+PEJSPg0KICAgICAgRmlyc3RseSBsb2NhdGUgdGhlIHJlc2V0IGJ1dHRvbiBvbiB0aGUgcmVhciBwYW5lbCBvZiB0aGUgdW5pdCwgd2hpbHN0IHRoZSBkZXZpY2UgaXMgcG93ZXJlZCBvbiBwcmVzcyBhbmQgaG9sZCB0aGUgPEI+cmVzZXQ8L0I+IGJ1dHRvbiBmb3IgbW9yZSB0aGFuIDUgc2Vjb25kcywgdGhlIGRldmljZSB3aWxsIHRoZW4gcmVib290IGFuZCByZXN0b3JlIGl0c2VsZiB0byB0aGUgZmFjdG9yeSBkZWZhdWx0IHNldHRpbmdzLiA8L1A+DQogIDwvRElWPg0KPC9ESVY+DQo8L0JPRFk+DQo8L0hUTUw+
+      name: Collection - /
+      description: 'Fetched from URL: http://example.com/'
+      content_type: text/html
+      server: Router Webserver
+      status_code: "401"
+      headers:
+        - 'Www-Authenticate: Basic realm="TP-LINK Wireless Lite N Router WR740N"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless Lite N Router WR741ND"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless Lite N Router WR743ND"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Router WR840N"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Router WR841N"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Router WR842ND"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Gigabit Router WR1042ND"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Gigabit Router WR1043ND"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N 3G Router MR3420"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Access Point WA701ND"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Access Point WA901ND"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK SOHO Router R402M"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Router WR941N"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless N Router WR941ND"'
+        - 'WWW-Authenticate: Basic realm="TP-LINK Wireless Router WR340G"'
+      created_at: 2025-01-14T14:10:32.188367Z
+      updated_at: 2025-01-14T14:20:46.354815Z
+      ext_version: 0
+      ext_uuid: c2298f9f-b466-4734-8973-9404bb8b38e2


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a single rule for multiple TP-Link routers.

- Defined rule metadata including IDs, URIs, and matching criteria.

- Included HTTP headers for various TP-Link router models.

- Added content details with HTML data and authentication realms.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TP-Link-Collection-multiple.yaml</strong><dd><code>Added rule for multiple TP-Link routers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/TP-Link/TP-Link-Collection-multiple.yaml

<li>Added a new rule for multiple TP-Link routers.<br> <li> Defined metadata such as IDs, URIs, and matching criteria.<br> <li> Included HTTP headers for authentication realms of various router <br>models.<br> <li> Added content details including HTML data and server response.


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/124/files#diff-fdd9d223782f213e0a05add76d106fe14f9716d6250c9dc31aa8171dfaf33169">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information