### PR TITLE
Use thread-safe regex initialization  

### DIFF
--- a/pkg/util/templator/templator.go
+++ b/pkg/util/templator/templator.go
@@ -21,21 +21,34 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"sync"
 )
 
 type Templator struct {
 	stringTagRegex *regexp.Regexp
 }
 
+var (
+	once          sync.Once
+	compiledRegex *regexp.Regexp
+)
+
 func NewTemplator() *Templator {
-	reg, err := regexp.Compile(`(%%STRING%%.+%%[0-9]+%%)`)
-	if err != nil {
-		slog.Error("failed to compile regex", slog.String("error", err.Error()))
+	once.Do(func() {
+		var err error
+		compiledRegex, err = regexp.Compile(`(%%STRING%%.+%%[0-9]+%%)`)
+		if err != nil {
+			slog.Error("failed to compile regex", slog.String("error", err.Error()))
+			return
+		}
+	})
+
+	if compiledRegex == nil {
 		return nil
 	}
 
 	return &Templator{
-		stringTagRegex: reg,
+		stringTagRegex: compiledRegex,
 	}
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Introduced thread-safe initialization for regex compilation using `sync.Once`.

- Replaced direct regex compilation with a singleton pattern.

- Improved error handling for regex compilation failures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>templator.go</strong><dd><code>Thread-safe regex initialization with `sync.Once`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/templator/templator.go

<li>Added <code>sync.Once</code> for thread-safe regex initialization.<br> <li> Replaced inline regex compilation with a singleton pattern.<br> <li> Enhanced error handling to prevent nil regex usage.


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/135/files#diff-5cb0cc3f13ffe1bd5690e572e16f0b882880d9fdbce7d1cedaf52124145acd2a">+17/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>