### PR TITLE
Add ability to run callback on locked map

### DIFF
--- a/pkg/util/string_map_cache.go
+++ b/pkg/util/string_map_cache.go
@@ -97,7 +97,7 @@ func (r *StringMapCache[T]) Replace(key string, data T) error {
 }
 
 // Check will lock the entry for `key` and will give run callback on the entry.
-// This is useful if you want to check someting in the map while having the
+// This is useful if you want to check something in the map while having the
 // lock.
 func (r *StringMapCache[T]) Check(key string, callback func(T) bool) (bool, error) {
 	r.mu.Lock()

--- a/pkg/util/string_map_cache.go
+++ b/pkg/util/string_map_cache.go
@@ -96,6 +96,21 @@ func (r *StringMapCache[T]) Replace(key string, data T) error {
 	return nil
 }
 
+// Check will lock the entry for `key` and will give run callback on the entry.
+// This is useful if you want to check someting in the map while having the
+// lock.
+func (r *StringMapCache[T]) Check(key string, callback func(T) bool) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.entries[key]
+	if !ok {
+		return false, fmt.Errorf("no entry for key %s", key)
+	}
+
+	return callback(entry.Data), nil
+}
+
 func (r *StringMapCache[T]) Get(key string) (*T, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a `Check` method to `StringMapCache` for executing callbacks on locked entries.

- Implemented tests for the new `Check` method, covering various scenarios.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>string_map_cache.go</strong><dd><code>Introduced `Check` method for locked entry callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/string_map_cache.go

<li>Added a new <code>Check</code> method to <code>StringMapCache</code>.<br> <li> The method locks an entry and executes a callback on it.<br> <li> Returns a boolean result and error if the key is missing.


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/185/files#diff-0ab41f6168af62cb8c68239c7c78cd0e807513c6264c91521b0f218500cbdb17">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>string_map_cache_test.go</strong><dd><code>Added tests for `Check` method in `StringMapCache`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/string_map_cache_test.go

<li>Added tests for the <code>Check</code> method in <code>StringMapCache</code>.<br> <li> Covered scenarios for valid keys, invalid keys, and callback logic.<br> <li> Verified callback behavior with complex logic and data capture.


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/185/files#diff-e38b425235d6b0c154c729eb9933cee9b331bd2ca591d210b0b5726036a00054">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>