### PR TITLE
Improve key comparison to prevent timing attacks

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -135,8 +135,8 @@ func (a *ApiServer) AuthMW(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key := r.Header.Get("API-Key")
 
-		if key != a.apiKey {
-			slog.Error("Did not get a valid API key")
+		if subtle.ConstantTimeCompare([]byte(key), []byte(a.apiKey)) != 1 {
+			slog.Error("Did not get a valid API key. ")
 			http.Error(w, "Authentication error", http.StatusForbidden)
 			return
 		}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replaced insecure string comparison with constant-time comparison.

- Added missing `crypto/subtle` import for secure comparison.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Secure API key comparison using constant-time function</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/api/server.go

<li>Replaced string comparison with <code>subtle.ConstantTimeCompare</code>.<br> <li> Added <code>crypto/subtle</code> import for secure comparison.<br> <li> Improved error handling for invalid API keys.


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/191/files#diff-734f9c34b34af099d24da13054e167f7df72706dc733edf21c61c0cc1548224a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>