### PR TITLE
Allow rules to "block" requests from further processing

### DIFF
--- a/config/database.sql
+++ b/config/database.sql
@@ -111,6 +111,7 @@ CREATE TABLE content_rule (
   responder_regex VARCHAR(1024) default '',
   responder_decoder RESPONDER_DECODER_TYPE default 'NONE',
   enabled         BOOL DEFAULT TRUE,
+  block           BOOL DEFAULT FALSE,
   CONSTRAINT fk_content_id FOREIGN KEY(content_id) REFERENCES content(id)
 );
 

--- a/pkg/agent/http_server.go
+++ b/pkg/agent/http_server.go
@@ -191,10 +191,21 @@ func (h *HttpServer) catchAll(w http.ResponseWriter, r *http.Request) {
 		log.Printf("unable to process request: %+v", err)
 
 		if st, ok := status.FromError(err); ok {
-			if st.Code() == codes.ResourceExhausted {
-				w.WriteHeader(http.StatusNotFound)
-				w.Write([]byte("<html></html>"))
-				return
+			switch st.Code() {
+				case codes.PermissionDenied:
+					w.WriteHeader(http.StatusForbidden)
+					w.Write([]byte("<html></html>"))
+					return
+
+				case codes.ResourceExhausted:
+					w.WriteHeader(http.StatusServiceUnavailable)
+					w.Write([]byte("<html></html>"))
+					return
+
+				default:
+					w.WriteHeader(http.StatusNotFound)
+					w.Write([]byte("<html></html>"))
+					return
 			}
 		} else {
 			w.WriteHeader(http.StatusOK)

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -937,6 +937,10 @@ func (s *BackendServer) HandleProbe(ctx context.Context, req *backend_service.Ha
 		}
 	}
 
+	if matchedRule.Block {
+		return nil, status.Errorf(codes.PermissionDenied, "Rule blocks request")
+	}
+
 	sReq.ContentID = matchedRule.ContentID
 	sReq.RuleID = matchedRule.ID
 	sReq.AppID = matchedRule.AppID

--- a/pkg/database/models/content_rule.go
+++ b/pkg/database/models/content_rule.go
@@ -49,6 +49,7 @@ type ContentRule struct {
 	UpdatedAt   time.Time `ksql:"updated_at,timeNowUTC" json:"updated_at" yaml:"updated_at" doc:"Last update date of the rule"`
 	Alert       bool      `ksql:"alert" json:"alert" doc:"A bool (0 or 1) indicating if the rule should alert"`
 	Enabled     bool      `ksql:"enabled" json:"enabled" doc:"A bool (0 or 1) indicating if the rule is enabled"`
+	Block       bool      `ksql:"block" json:"block" doc:"A bool (0 or 1) indicating if requests matching the rule should be blocked"`
 	ExtVersion  int64     `ksql:"ext_version" json:"ext_version" yaml:"ext_version" doc:"The external numerical version of the rule"`
 	ExtUuid     string    `ksql:"ext_uuid" json:"ext_uuid" yaml:"ext_uuid" doc:"The external unique ID of the rule"`
 	// The request purpose should indicate what the request is intended to do. It

--- a/ui/src/components/container/RuleForm.vue
+++ b/ui/src/components/container/RuleForm.vue
@@ -207,6 +207,16 @@
                   />
                 </td>
               </tr>
+              <tr>
+                <th>Block</th>
+                <td>
+                  <CheckBox
+                    inputId="block"
+                    v-model="localRule.block"
+                    :binary="true"
+                  />
+                </td>
+              </tr>
             </table>
           </div>
         </div>
@@ -311,6 +321,7 @@ export default {
         responder: "NONE",
         responder_decoder: "NONE",
         enabled: true,
+        block: false,
         ports: [],
         parsed: {
           port_field: "",


### PR DESCRIPTION
Some requests are just not interesting but come in large amounts. Many bruteforce attacks are like this. They can be managed with the ratelimiting but when the last for a long time there will still be a significant amount of requests that makes it to the database and they just consume space.

By selecting the "block" checkbox in the rule you will now cause the backend to drop any further processing of a request when it matches that rule.