### PR TITLE
Also exclude user-agent from compare hashing

### DIFF
--- a/pkg/database/hashing.go
+++ b/pkg/database/hashing.go
@@ -100,7 +100,7 @@ func GetSameRequestHash(req *models.Request) (string, error) {
 		headerFields = append(headerFields, headerArray[0])
 
 		if len(headerArray) == 2 {
-			if strings.ToLower(headerArray[0]) == "host" {
+			if strings.ToLower(headerArray[0]) == "host" || strings.ToLower(headerArray[0]) == "user-agent" {
 				continue
 			}
 


### PR DESCRIPTION
This is mainly to reduce the amount of requests we send to the LLMs for describing requests.  User-agents are often random and not so interesting anyway.  Only downside is when the payload is in the user-agent which is rare.