### PR TITLE
Ensure more exact matched rules get priority

### DIFF
--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -73,6 +73,8 @@ func TestGetMatchedRuleBasic(t *testing.T) {
 		{ID: 10, AppID: 9, Method: "GET", Ports: []int{80}, Body: "/etc/passwd", BodyMatching: "contains", ContentID: 42},
 		{ID: 11, AppID: 9, Method: "GET", Ports: []int{80}, Uri: "/pppaaattthhh", UriMatching: "exact", Body: "/etc/hosts", BodyMatching: "contains", ContentID: 42},
 		{ID: 12, AppID: 4, Method: "POST", Ports: []int{80}, Uri: "suffix", UriMatching: "suffix", ContentID: 77},
+		{ID: 13, AppID: 4, Method: "POST", Ports: []int{80}, Uri: "/same", UriMatching: "exact", Body: "body", BodyMatching: "exact", ContentID: 77},
+		{ID: 14, AppID: 4, Method: "POST", Ports: []int{80}, Uri: "/same", UriMatching: "exact", ContentID: 77},
 	}
 
 	for _, test := range []struct {
@@ -172,6 +174,19 @@ func TestGetMatchedRuleBasic(t *testing.T) {
 			errorExpected:         false,
 		},
 		{
+			description: "matched one rule (uri and body)  ",
+			requestInput: models.Request{
+				Uri:    "/same",
+				Port:   80,
+				Body:   []byte("body"),
+				Method: "POST",
+			},
+			contentRulesInput:     bunchOfRules,
+			contentRuleIDExpected: 13,
+			errorExpected:         false,
+		},
+
+		{
 			description: "matched on body alone (exact) ",
 			requestInput: models.Request{
 				Uri:    "/eeee",
@@ -183,6 +198,7 @@ func TestGetMatchedRuleBasic(t *testing.T) {
 			contentRuleIDExpected: 9,
 			errorExpected:         false,
 		},
+
 		{
 			description: "matched on body alone (contains) ",
 			requestInput: models.Request{


### PR DESCRIPTION
### **User description**
Described here https://github.com/mrheinen/lophiid/issues/240


___

### **PR Type**
Enhancement


___

### **Description**
- Implement rule prioritization system for content matching

- Rules with both URI and body criteria get higher priority

- Single-criteria rules serve as fallback option

- Add comprehensive test coverage for priority scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incoming Request"] --> B["Match Rules"]
  B --> C["Priority 1: Single Criteria"]
  B --> D["Priority 2: Multiple Criteria"]
  D --> E["Return Priority 2 Rules"]
  C --> F["Return Priority 1 Rules"]
  E --> G["Serve Response"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend.go</strong><dd><code>Implement two-tier rule prioritization system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/backend.go

<ul><li>Replace single <code>matchedRules</code> slice with two priority arrays<br> <li> Separate rules by matching criteria count (URI+body vs single)<br> <li> Return higher priority rules when available, fallback otherwise<br> <li> Add explanatory comments for prioritization logic</ul>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/241/files#diff-c65bcfe9bb457434c3e69ba3f0576d7669935f350d24e2c2c58b05b4f9c510b2">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_test.go</strong><dd><code>Add test coverage for rule prioritization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/backend/backend_test.go

<ul><li>Add two new test rules with same URI but different criteria<br> <li> Create test case for URI+body matching scenario<br> <li> Verify priority 2 rule (ID 13) is selected over priority 1 rule (ID <br>14)</ul>


</details>


  </td>
  <td><a href="https://github.com/mrheinen/lophiid/pull/241/files#diff-841290eccbd676c43597489825cc8f1628359283c634321e496e76e31f6fed9c">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

